### PR TITLE
fix(federation): harden HTTP signatures, SSRF, and Delete/ingest auth

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -254,6 +254,12 @@ AP_ACCEPTED_ACTIVITIES = [
     "Offer",
 ]
 
+# Maximum allowed clock skew (seconds) between an incoming request's signed
+# Date header and server time before the signature is rejected as a replay.
+# 30s is too aggressive for real-world clock drift across federated peers;
+# Mastodon uses a comparable window (SUD-F2).
+AP_SIGNATURE_MAX_SKEW = int(os.environ.get("AP_SIGNATURE_MAX_SKEW", "300"))
+
 # =================================================================
 # INGESTION
 # =================================================================

--- a/suddenly/activitypub/_http.py
+++ b/suddenly/activitypub/_http.py
@@ -7,20 +7,33 @@ signature verification, inbox processing, and Celery delivery tasks.
 
 from __future__ import annotations
 
+import ipaddress
 import logging
+import socket
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 logger = logging.getLogger(__name__)
+
+
+def _is_blocked_ip(ip: str) -> bool:
+    """Return True if an IP is private, loopback, or link-local (SSRF target)."""
+    try:
+        ip_obj = ipaddress.ip_address(ip)
+    except ValueError:
+        return True
+    return bool(ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_link_local)
 
 
 def fetch_ap_actor(url: str, *, timeout: int = 10) -> dict[str, Any] | None:
     """
     Fetch an ActivityPub actor JSON document with SSRF protection.
 
-    Blocks requests to private, loopback, or link-local addresses by
-    resolving the hostname before issuing the HTTP request. Only http/https
-    schemes are allowed.
+    Resolves the hostname once, blocks private/loopback/link-local addresses,
+    then connects directly to the validated IP so httpx cannot re-resolve the
+    name and land on a different (internal) address — closing the DNS-rebinding
+    TOCTOU window (SUD-F3). TLS SNI and certificate verification still use the
+    original hostname. Only http/https schemes are allowed.
 
     Args:
         url: The actor URL to fetch.
@@ -29,36 +42,47 @@ def fetch_ap_actor(url: str, *, timeout: int = 10) -> dict[str, Any] | None:
     Returns:
         The parsed actor dict on a 200 response, or None on any failure.
     """
-    import socket
-
     import httpx
 
     parsed = urlparse(url)
     if parsed.scheme not in ("http", "https"):
         return None
 
-    # Block private/loopback IPs (SSRF protection)
     hostname = parsed.hostname
-    if hostname:
-        try:
-            resolved = socket.getaddrinfo(hostname, None)
-            for _, _, _, _, addr in resolved:
-                ip = addr[0]
-                import ipaddress
+    if not hostname:
+        return None
 
-                ip_obj = ipaddress.ip_address(ip)
-                if ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_link_local:
-                    logger.warning("Blocked SSRF attempt to %s (%s)", url, ip)
-                    return None
-        except (socket.gaierror, ValueError):
-            pass  # DNS resolution failed or invalid IP — let httpx handle it
+    # Resolve once. The IP we validate here is the exact IP we connect to below.
+    try:
+        resolved = socket.getaddrinfo(hostname, parsed.port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        resolved = []
+
+    pinned_ip: str | None = None
+    for _family, _type, _proto, _canon, sockaddr in resolved:
+        ip = str(sockaddr[0])
+        if _is_blocked_ip(ip):
+            logger.warning("Blocked SSRF attempt to %s (%s)", url, ip)
+            return None
+        if pinned_ip is None:
+            pinned_ip = ip
+
+    request_url = url
+    headers = {"Accept": "application/activity+json, application/ld+json"}
+    extensions: dict[str, Any] = {}
+
+    if pinned_ip is not None:
+        # Connect straight to the validated IP; keep the Host header and use the
+        # original hostname for TLS SNI + cert verification via httpx extensions.
+        ip_host = f"[{pinned_ip}]" if ":" in pinned_ip else pinned_ip
+        connect_netloc = f"{ip_host}:{parsed.port}" if parsed.port else ip_host
+        request_url = urlunparse(parsed._replace(netloc=connect_netloc))
+        headers["Host"] = f"{hostname}:{parsed.port}" if parsed.port else hostname
+        extensions["sni_hostname"] = hostname
 
     try:
         with httpx.Client(timeout=timeout) as client:
-            resp = client.get(
-                url,
-                headers={"Accept": "application/activity+json, application/ld+json"},
-            )
+            resp = client.get(request_url, headers=headers, extensions=extensions)
         if resp.status_code == 200:
             return resp.json()  # type: ignore[no-any-return]
     except Exception:

--- a/suddenly/activitypub/inbox.py
+++ b/suddenly/activitypub/inbox.py
@@ -417,22 +417,37 @@ def handle_delete(activity: dict[str, Any], actor_type: str, actor_identifier: s
     Supports Character and User (actor tombstone).
     """
     obj = activity.get("object")
+    actor_url = activity.get("actor", "")
 
-    logger.info(f"Received Delete from {activity.get('actor')}")
+    logger.info(f"Received Delete from {actor_url}")
 
     if isinstance(obj, str):
         # object is a URL — determine the type by trying known models
-        _handle_delete_by_url(obj)
+        _handle_delete_by_url(obj, actor_url)
     elif isinstance(obj, dict):
         obj_id = obj.get("id", "")
         if obj_id:
-            _handle_delete_by_url(obj_id)
+            _handle_delete_by_url(obj_id, actor_url)
 
 
-def _handle_delete_by_url(ap_id: str) -> None:
-    """Delete any remote entity matching the given ap_id."""
+def _handle_delete_by_url(ap_id: str, actor_url: str) -> None:
+    """Delete a remote entity matching ap_id, only if it belongs to the signer.
+
+    The signature proves *who* sent the Delete and process_inbox already binds
+    the actor domain to the signing domain. Here we additionally require the
+    deleted object to live on the actor's own domain, so instance A cannot sign
+    a Delete for an object hosted by instance B (SUD-F6).
+    """
     from suddenly.characters.models import Character
     from suddenly.users.models import User
+
+    actor_domain = urlparse(actor_url).hostname
+    target_domain = urlparse(ap_id).hostname
+    if not actor_domain or not target_domain or actor_domain != target_domain:
+        logger.warning(
+            "Rejected cross-domain Delete: actor=%s target=%s", actor_url, ap_id
+        )
+        return
 
     deleted, _ = Character.objects.filter(ap_id=ap_id, remote=True).delete()
     if deleted:

--- a/suddenly/activitypub/serializers.py
+++ b/suddenly/activitypub/serializers.py
@@ -12,18 +12,30 @@ from django.conf import settings
 
 from suddenly.activitypub.url_utils import absolute_media_url, media_type_for_file
 
-# ActivityPub context
+# ActivityPub context.
+#
+# Type strategy (SUD-F5): Characters serialize as a standard AP ``Person`` so
+# generic consumers can display them, with the ``suddenly:Character`` term
+# declared for Suddenly-aware peers to recognise the richer type. This dual
+# typing is intentional — a strict consumer sees a Person, never an unknown
+# type it might reject.
+#
+# ``sensitive`` is the Mastodon/AS2 Content-Warning flag emitted alongside
+# ``summary`` by serialize_report/serialize_quote; it must be declared here or
+# strict peers drop it. ``toot`` is declared for the Mastodon namespace.
 AP_CONTEXT: list[str | dict[str, str]] = [
     "https://www.w3.org/ns/activitystreams",
     "https://w3id.org/security/v1",
     {
         "suddenly": f"https://{settings.DOMAIN}/ns#",
+        "toot": "http://joinmastodon.org/ns#",
         "Character": "suddenly:Character",
         "Game": "suddenly:Game",
         "Quote": "suddenly:Quote",
         "status": "suddenly:status",
         "sheetUrl": "suddenly:sheetUrl",
         "gameSystem": "suddenly:gameSystem",
+        "sensitive": "https://www.w3.org/ns/activitystreams#sensitive",
     },
 ]
 

--- a/suddenly/activitypub/signatures.py
+++ b/suddenly/activitypub/signatures.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import hmac
 import logging
 from datetime import UTC, datetime
 from urllib.parse import urlparse
@@ -249,30 +250,49 @@ def verify_signature(request: HttpRequest) -> tuple[bool, str | None]:
     if algorithm != "rsa-sha256":
         return False, f"Unsupported algorithm: {algorithm}"
 
-    # Date skew check (replay protection). Some AP implementations omit the
-    # Date header — skip the check when absent or unparseable rather than reject.
-    date_header = request.headers.get("Date")
-    if date_header:
-        try:
-            ts = parse_http_date(date_header)
-        except ValueError:
-            pass
-        else:
-            dt = datetime.fromtimestamp(ts, tz=UTC)
-            if abs((timezone.now() - dt).total_seconds()) > 30:
-                return False, "Date skew"
+    signed_headers = headers_str.split()
+    signed_set = {h.lower() for h in signed_headers}
 
-    # Verify Digest header matches actual body (prevents body tampering)
-    digest_header = request.headers.get("Digest")
-    if digest_header and request.body:
+    # Date skew check (replay protection). The Date header is mandatory and must
+    # be covered by the signature — an absent or unsigned Date leaves the request
+    # replayable indefinitely (SUD-F2). Reject rather than skip silently.
+    date_header = request.headers.get("Date")
+    if not date_header:
+        return False, "Missing Date header"
+    try:
+        ts = parse_http_date(date_header)
+    except ValueError:
+        return False, "Invalid Date header"
+    dt = datetime.fromtimestamp(ts, tz=UTC)
+    max_skew = getattr(settings, "AP_SIGNATURE_MAX_SKEW", 300)
+    if abs((timezone.now() - dt).total_seconds()) > max_skew:
+        return False, "Date skew"
+
+    # Enforce a minimum signed header set (SUD-F2). (request-target) and host
+    # bind the signature to this exact endpoint; date bounds replay. A peer that
+    # signs only a subset can otherwise redirect or replay the request.
+    required_signed = {"(request-target)", "host", "date"}
+    missing_signed = required_signed - signed_set
+    if missing_signed:
+        return False, f"Unsigned required headers: {', '.join(sorted(missing_signed))}"
+
+    # Any request carrying a body must authenticate it with a signed Digest that
+    # matches the body (SUD-F1). Without this, a peer can sign only benign
+    # headers and deliver arbitrary activity content under a legitimate key.
+    if request.body:
+        if "digest" not in signed_set:
+            return False, "Digest not covered by signature"
+        digest_header = request.headers.get("Digest")
+        if not digest_header:
+            return False, "Missing Digest header"
         expected_digest = "SHA-256=" + base64.b64encode(
             hashlib.sha256(request.body).digest()
         ).decode("utf-8")
-        if digest_header != expected_digest:
+        if not hmac.compare_digest(digest_header, expected_digest):
             return False, "Digest mismatch"
 
     actor_url = key_id.split("#")[0]
-    signing_string = _build_signing_string(request, headers_str.split())
+    signing_string = _build_signing_string(request, signed_headers)
 
     # Try cached key first
     cached = PublicKeyCache.objects.filter(actor_url=actor_url).first()

--- a/suddenly/games/ingest.py
+++ b/suddenly/games/ingest.py
@@ -10,6 +10,8 @@ creates a published Report, and lets the AP signal broadcast it.
 
 from __future__ import annotations
 
+import hmac
+
 from django.conf import settings
 from rest_framework import serializers, status
 from rest_framework.permissions import AllowAny
@@ -100,7 +102,8 @@ class IngestReportView(APIView):  # type: ignore[misc]
         if not expected:
             return False
         provided = request.headers.get("X-Ingest-Token", "")
-        return bool(provided == expected)
+        # Constant-time compare to avoid leaking the shared secret via timing.
+        return hmac.compare_digest(provided, expected)
 
     def post(self, request: Request) -> Response:
         if not self._check_token(request):

--- a/tests/activitypub/test_delete_authorization.py
+++ b/tests/activitypub/test_delete_authorization.py
@@ -1,0 +1,65 @@
+"""
+Tests for Delete object authorization (SUD-F6).
+
+A Delete only removes an object that lives on the *signing actor's own domain*.
+This prevents instance A from signing a Delete for an object hosted by
+instance B.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from suddenly.activitypub.inbox import handle_delete
+from suddenly.characters.models import Character, CharacterStatus
+from suddenly.games.models import Game
+from suddenly.users.models import User
+
+
+def _make_remote_character(ap_id: str, actor_url: str) -> Character:
+    owner = User.objects.create(
+        username=f"owner@{ap_id}",
+        remote=True,
+        ap_id=actor_url,
+    )
+    game = Game.objects.create(title="Remote", owner=owner, remote=True, ap_id=f"{actor_url}/game")
+    return Character.objects.create(
+        name="Aria",
+        status=CharacterStatus.NPC,
+        creator=owner,
+        origin_game=game,
+        remote=True,
+        ap_id=ap_id,
+    )
+
+
+@pytest.mark.django_db
+class TestDeleteAuthorization:
+    def test_same_domain_delete_removes_record(self, db: Any) -> None:
+        actor = "https://peer.example/users/sender"
+        target = "https://peer.example/characters/aria"
+        _make_remote_character(target, actor)
+
+        handle_delete(
+            {"type": "Delete", "actor": actor, "object": target},
+            actor_type="user",
+            actor_identifier="local",
+        )
+
+        assert not Character.objects.filter(ap_id=target).exists()
+
+    def test_cross_domain_delete_is_rejected(self, db: Any) -> None:
+        actor = "https://evil.example/users/attacker"
+        target = "https://victim.example/characters/aria"
+        _make_remote_character(target, "https://victim.example/users/owner")
+
+        handle_delete(
+            {"type": "Delete", "actor": actor, "object": target},
+            actor_type="user",
+            actor_identifier="local",
+        )
+
+        # The victim's character must survive a cross-domain Delete.
+        assert Character.objects.filter(ap_id=target).exists()

--- a/tests/activitypub/test_quick_wins.py
+++ b/tests/activitypub/test_quick_wins.py
@@ -41,9 +41,9 @@ class TestSsrfBlock:
 class TestDateSkewReject:
     """verify_signature must reject a stale Date header (replay protection)."""
 
-    def test_date_60s_in_past_rejected(self, rf: RequestFactory) -> None:
-        """A Date header 60s in the past returns (False, 'Date skew')."""
-        stale = datetime.now(UTC) - timedelta(seconds=60)
+    def test_stale_date_rejected(self, rf: RequestFactory) -> None:
+        """A Date header beyond the skew window returns (False, 'Date skew')."""
+        stale = datetime.now(UTC) - timedelta(seconds=600)
         date_str = stale.strftime("%a, %d %b %Y %H:%M:%S GMT")
 
         sig_header = (

--- a/tests/activitypub/test_signature_hardening.py
+++ b/tests/activitypub/test_signature_hardening.py
@@ -1,0 +1,203 @@
+"""
+Tests for HTTP Signature hardening (SUD-F1, SUD-F2).
+
+Covers the requirements added to ``verify_signature``:
+- A body must be authenticated by a signed, matching Digest (SUD-F1).
+- Date must be present and signed; the skew window rejects stale requests.
+- A minimum signed header set — (request-target), host, date — is enforced
+  so a peer cannot sign only a trivial subset (SUD-F2).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from datetime import UTC, datetime
+from typing import Any, cast
+from urllib.parse import urlparse
+
+import pytest
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+from django.test import RequestFactory
+
+from suddenly.activitypub.signatures import generate_key_pair, verify_signature
+
+# verify_signature reads PublicKeyCache before hitting the network mock.
+pytestmark = pytest.mark.django_db
+
+KEY_ID = "https://remote.example/actor#main-key"
+PATH = "/users/testuser/inbox"
+
+
+def _sign(
+    private_pem: str,
+    *,
+    body: str,
+    signed_headers: list[str],
+    date_str: str | None,
+    digest_value: str | None,
+    include_digest_header: bool = True,
+) -> Any:
+    """Build a POST request signed over exactly ``signed_headers``.
+
+    ``digest_value`` controls the value used both in the signing string and the
+    Digest header, letting tests sign one thing and send another.
+    """
+    parsed = urlparse(f"https://test.social{PATH}")
+    host = parsed.netloc
+    if date_str is None:
+        date_str = datetime.now(UTC).strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+    available = {
+        "(request-target)": f"(request-target): post {parsed.path}",
+        "host": f"host: {host}",
+        "date": f"date: {date_str}",
+    }
+    if digest_value is not None:
+        available["digest"] = f"digest: {digest_value}"
+
+    signing_string = "\n".join(available[h] for h in signed_headers)
+
+    private_key = cast(
+        RSAPrivateKey,
+        serialization.load_pem_private_key(
+            private_pem.encode(), password=None, backend=default_backend()
+        ),
+    )
+    sig = base64.b64encode(
+        private_key.sign(signing_string.encode(), padding.PKCS1v15(), hashes.SHA256())
+    ).decode()
+
+    sig_header = (
+        f'keyId="{KEY_ID}",'
+        f'algorithm="rsa-sha256",'
+        f'headers="{" ".join(signed_headers)}",'
+        f'signature="{sig}"'
+    )
+
+    meta: dict[str, Any] = {
+        "HTTP_HOST": host,
+        "HTTP_DATE": date_str,
+        "HTTP_SIGNATURE": sig_header,
+    }
+    if digest_value is not None and include_digest_header:
+        meta["HTTP_DIGEST"] = digest_value
+
+    return RequestFactory().post(
+        PATH, data=body, content_type="application/activity+json", **meta
+    )
+
+
+def _digest_of(body: str) -> str:
+    return "SHA-256=" + base64.b64encode(hashlib.sha256(body.encode()).digest()).decode()
+
+
+@pytest.fixture
+def keys() -> tuple[str, str]:
+    return generate_key_pair()
+
+
+def _mock_key(mocker: Any, public_pem: str) -> None:
+    mocker.patch(
+        "suddenly.activitypub.signatures._fetch_public_key",
+        return_value=public_pem,
+    )
+
+
+class TestDigestRequired:
+    """SUD-F1: a body must be covered by a signed, matching Digest."""
+
+    def test_valid_signed_digest_accepted(self, keys: tuple[str, str], mocker: Any) -> None:
+        private_pem, public_pem = keys
+        _mock_key(mocker, public_pem)
+        body = json.dumps({"type": "Follow"})
+        request = _sign(
+            private_pem,
+            body=body,
+            signed_headers=["(request-target)", "host", "date", "digest"],
+            date_str=None,
+            digest_value=_digest_of(body),
+        )
+        is_valid, result = verify_signature(request)
+        assert is_valid is True
+        assert result == KEY_ID
+
+    def test_body_without_signed_digest_rejected(
+        self, keys: tuple[str, str], mocker: Any
+    ) -> None:
+        """A validly-signed request that omits digest from the signed set fails."""
+        private_pem, public_pem = keys
+        _mock_key(mocker, public_pem)
+        body = json.dumps({"type": "Delete"})
+        request = _sign(
+            private_pem,
+            body=body,
+            signed_headers=["(request-target)", "host", "date"],
+            date_str=None,
+            digest_value=None,
+        )
+        is_valid, reason = verify_signature(request)
+        assert is_valid is False
+        assert reason == "Digest not covered by signature"
+
+    def test_digest_mismatch_rejected(self, keys: tuple[str, str], mocker: Any) -> None:
+        """Digest signed but not matching the delivered body → rejected."""
+        private_pem, public_pem = keys
+        _mock_key(mocker, public_pem)
+        signed_body = json.dumps({"type": "Follow"})
+        wrong_digest = _digest_of(signed_body)
+        # Sign over wrong_digest, then deliver a different body.
+        request = _sign(
+            private_pem,
+            body=json.dumps({"type": "Delete"}),
+            signed_headers=["(request-target)", "host", "date", "digest"],
+            date_str=None,
+            digest_value=wrong_digest,
+        )
+        is_valid, reason = verify_signature(request)
+        assert is_valid is False
+        assert reason == "Digest mismatch"
+
+
+class TestMinimumSignedHeaders:
+    """SUD-F2: date mandatory + signed, and a minimum signed header set."""
+
+    def test_missing_date_rejected(self, keys: tuple[str, str], mocker: Any) -> None:
+        private_pem, public_pem = keys
+        _mock_key(mocker, public_pem)
+        body = json.dumps({"type": "Follow"})
+        request = _sign(
+            private_pem,
+            body=body,
+            signed_headers=["(request-target)", "host", "date", "digest"],
+            date_str=None,
+            digest_value=_digest_of(body),
+        )
+        # Strip the Date header the client would otherwise send.
+        del request.META["HTTP_DATE"]
+        is_valid, reason = verify_signature(request)
+        assert is_valid is False
+        assert reason == "Missing Date header"
+
+    def test_request_target_not_signed_rejected(
+        self, keys: tuple[str, str], mocker: Any
+    ) -> None:
+        private_pem, public_pem = keys
+        _mock_key(mocker, public_pem)
+        body = json.dumps({"type": "Follow"})
+        request = _sign(
+            private_pem,
+            body=body,
+            signed_headers=["host", "date", "digest"],
+            date_str=None,
+            digest_value=_digest_of(body),
+        )
+        is_valid, reason = verify_signature(request)
+        assert is_valid is False
+        assert reason is not None
+        assert "Unsigned required headers" in reason
+        assert "(request-target)" in reason

--- a/tests/games/test_ingest_token.py
+++ b/tests/games/test_ingest_token.py
@@ -1,0 +1,41 @@
+"""
+Tests for the ingest endpoint token check (SUD-F7).
+
+The X-Ingest-Token comparison must be constant-time and behave correctly for
+matching, mismatching, and missing tokens.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from rest_framework.test import APIRequestFactory
+
+from suddenly.games.ingest import IngestReportView
+
+
+def _check(token_header: str | None, settings: Any, configured: str = "s3cr3t") -> bool:
+    settings.INGEST_TOKEN = configured
+    headers = {"HTTP_X_INGEST_TOKEN": token_header} if token_header is not None else {}
+    request = APIRequestFactory().post("/api/games/reports/ingest/", **headers)
+    return IngestReportView()._check_token(request)
+
+
+class TestIngestTokenCheck:
+    def test_matching_token_accepted(self, settings: Any) -> None:
+        assert _check("s3cr3t", settings) is True
+
+    def test_wrong_token_rejected(self, settings: Any) -> None:
+        assert _check("nope", settings) is False
+
+    def test_missing_token_rejected(self, settings: Any) -> None:
+        assert _check(None, settings) is False
+
+    def test_no_configured_token_rejects_all(self, settings: Any) -> None:
+        assert _check("anything", settings, configured="") is False
+
+
+@pytest.mark.parametrize("provided", ["", "S3CR3T", "s3cr3t "])
+def test_near_misses_rejected(provided: str, settings: Any) -> None:
+    assert _check(provided, settings) is False


### PR DESCRIPTION
Addresses the federation security audit findings (SUD-F1..F3, F5..F7):

- SUD-F1/F2: verify_signature now requires a signed, matching Digest on any
  request with a body, mandates a signed Date within a configurable skew
  window (AP_SIGNATURE_MAX_SKEW, default 300s), and enforces a minimum signed
  header set — (request-target), host, date. A peer can no longer sign only
  trivial headers and inject an unauthenticated activity body or replay a
  captured request.
- SUD-F3: fetch_ap_actor pins the validated IP onto the connection (connect to
  the resolved IP, preserve Host header, verify TLS against the original
  hostname via sni_hostname) so httpx cannot re-resolve to an internal address,
  closing the DNS-rebinding TOCTOU window.
- SUD-F5: declare the emitted `sensitive` (Content Warning) term and the Toot
  namespace in the AP @context; document the intentional dual
  Person/suddenly:Character typing.
- SUD-F6: Delete only removes an object hosted on the signing actor's own
  domain, blocking cross-instance Delete forgery.
- SUD-F7: ingest token check uses hmac.compare_digest (constant-time).

Adds tests for the signature hardening, cross-domain Delete rejection, and the
ingest token comparison. SUD-F4 (sharedInbox fan-out) is left as a follow-up.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YUJZ1RKPPuoAdtMLGQskkV