### PR TITLE
test(games,characters): fix three Epic D test bugs (unfollow lock, cast teardown, released retro-compat)

### DIFF
--- a/tests/characters/test_follow_lock.py
+++ b/tests/characters/test_follow_lock.py
@@ -65,6 +65,12 @@ def test_unfollow_allowed_once_game_closed(client: Client) -> None:
     gm, player, game = _make_co_members()
     from suddenly.games.services import close_game
 
+    # DEC-D5: an AUTO follow is torn down when the game closes, so the follow
+    # that must "still be there after close" (and then be unfollowable) is a
+    # MANUAL one — teardown never touches auto=False.
+    Follow.objects.filter(follower=player, content_type=_user_ct(), object_id=gm.pk).update(
+        auto=False
+    )
     close_game(game=game, user=gm)
 
     client.force_login(player)

--- a/tests/games/test_cast_auto_follow.py
+++ b/tests/games/test_cast_auto_follow.py
@@ -168,7 +168,12 @@ def test_cast_remove_preserves_manual_follow_between_same_pair() -> None:
     game = GameFactory(owner=gm)
     pc = CharacterFactory(status="pc", owner=player, creator=player, origin_game=game)
     cast_row = GameCast.objects.create(game=game, character=pc, added_by=gm)
-    Follow.objects.create(follower=player, content_type=_user_ct(), object_id=gm.pk, auto=False)
+    # The cast sync already created player -> gm as an AUTO follow; the unique
+    # (follower, content_type, object_id) constraint forbids a second row, so
+    # turn that very follow MANUAL rather than creating a duplicate.
+    Follow.objects.filter(follower=player, content_type=_user_ct(), object_id=gm.pk).update(
+        auto=False
+    )
 
     cast_row.delete()
 

--- a/tests/games/test_game_completion.py
+++ b/tests/games/test_game_completion.py
@@ -24,15 +24,16 @@ from tests.factories import CharacterFactory, GameFactory, ReportFactory, UserFa
 
 
 def _published_unreleased(game: object, author: object, **kwargs: object) -> Report:
-    return ReportFactory(
-        game=game,
-        author=author,
-        status=ReportStatus.PUBLISHED,
-        visibility=ReportVisibility.PUBLIC,
-        published_at=timezone.now(),
-        released_at=None,
-        **kwargs,
-    )
+    fields: dict[str, object] = {
+        "game": game,
+        "author": author,
+        "status": ReportStatus.PUBLISHED,
+        "visibility": ReportVisibility.PUBLIC,
+        "published_at": timezone.now(),
+        "released_at": None,
+    }
+    fields.update(kwargs)  # a caller may override released_at (retro-compat case)
+    return ReportFactory(**fields)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Three tests carried self-inflicted bugs, not code defects — the Epic D
production behavior (DEC-D4/D5/D6) is correct.

- test_unfollow_allowed_once_game_closed: the AUTO follow is torn down when
  the game closes (DEC-D4), so the toggle re-created it instead of unfollowing.
  Per DEC-D5 the "still unfollowable after close" subject is a MANUAL follow
  (teardown never touches auto=False) — mark it MANUAL before closing.
- test_cast_remove_preserves_manual_follow_between_same_pair: cast sync already
  created player->gm as AUTO, so Follow.objects.create() for the same triple hit
  the unique constraint. Turn the existing row MANUAL via update() instead.
- test_released_retro_compat_without_completed_at: the _published_unreleased
  helper passed released_at=None positionally and again via **kwargs, raising
  "multiple values for keyword argument". Let kwargs override the default.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ec6tF7NAWxBm7YWbzbWK85