### PR TITLE
docs(quotes): purge Quote de la doc normative (#145, PR 2/2)

### DIFF
--- a/.claude/rules/08-domain/08-activitypub.md
+++ b/.claude/rules/08-domain/08-activitypub.md
@@ -49,7 +49,7 @@ paths:
 - Actor discovery via WebFinger (`/.well-known/webfinger`)
 - Instance metadata via NodeInfo 2.0 (`/.well-known/nodeinfo`)
 - Inbox handler must validate signature before processing
-- AP types: User=Person, Character=Person, Game=Collection, Report=Article, Quote=Note
+- AP types: User=Person, Character=Person, Game=Collection, Report=Article
 - Link requests (Claim/Adopt/Fork) use AP Offer type
 - No direct HTTP calls in views — use Celery tasks (or sync fallback) for federation delivery
 - Exception: `verify_signature()` does synchronous HTTP fetch (required before processing)

--- a/aidd_docs/memory/CODEBASE_MAP.md
+++ b/aidd_docs/memory/CODEBASE_MAP.md
@@ -41,7 +41,7 @@ flowchart TD
             GFO["Report fiction order — previous_report/next_reports (self-FK), temporal_kind/temporal_anchor/temporal_label; ReportTemporalKind"]
         end
         subgraph "characters/"
-            CH["Character (tags M2M) · Quote · CharacterAppearance"]
+            CH["Character (tags M2M) · CharacterAppearance"]
             CL["LinkRequest · CharacterLink · SharedSequence · Follow"]
             CS["LinkService (claim / adopt / fork)"]
         end

--- a/aidd_docs/memory/CODING_ASSERTIONS.md
+++ b/aidd_docs/memory/CODING_ASSERTIONS.md
@@ -111,8 +111,3 @@
 - Outgoing activity delivery is always async (never in request/response)
 - Rate limiting on outgoing sends to avoid spamming remote inboxes
 - Cross-instance link requests time out after **30 days** — value is fixed in code, not configurable yet
-
-## Domain Constants
-
-- `EPHEMERAL_QUOTE_TTL_HOURS = 24` — `EPHEMERAL` quote visibility lifetime, enforced by a scheduled cleanup task
-- `EPHEMERAL` quotes are never federated — the lifespan is too short to round-trip safely

--- a/aidd_docs/memory/DEPLOYMENT.md
+++ b/aidd_docs/memory/DEPLOYMENT.md
@@ -150,7 +150,6 @@ Site → Python WSGI
 **Scheduled tasks** (env vars must be set in each task):
 ```
 0 3 * * *  /home/<user>/www/<app>/venv/bin/python /home/<user>/www/<app>/manage.py clearsessions
-0 * * * *  /home/<user>/www/<app>/venv/bin/python /home/<user>/www/<app>/manage.py shell -c "from suddenly.activitypub.tasks import cleanup_expired_quotes; cleanup_expired_quotes()"
 ```
 
 - SSL: Let's Encrypt via Alwaysdata interface

--- a/aidd_docs/memory/PROJECT_BRIEF.md
+++ b/aidd_docs/memory/PROJECT_BRIEF.md
@@ -28,7 +28,6 @@
 | PNJ | Non-Player Character — created in a report, available for adoption | NPC |
 | Partie / Jeu | Ongoing fiction receiving reports | Game, Campaign |
 | Compte-rendu | Narrative session log (Markdown) | Report |
-| Citation | Memorable character quote (public/private/ephemeral) | Quote |
 | Claim | Retcon: the NPC was always the requester's PC | — |
 | Adopt | Takeover: NPC becomes requester's new PC | — |
 | Fork | Derivation: new PC inspired by NPC, lineage link | — |
@@ -46,7 +45,6 @@
 - Send claim/adopt/fork requests on available NPCs
 - Accept/reject requests (NPC creator's role)
 - Follow users, games, and characters (local and federated)
-- Publish memorable character quotes (configurable visibility)
 - Federation via ActivityPub: WebFinger, NodeInfo, inbox/outbox
 
 ## User Journey maps
@@ -125,7 +123,6 @@ journey
 | Entity | AP Type | Description |
 |--------|---------|-------------|
 | Report | Article | Session report |
-| Quote | Note | Character quote |
 
 ### Character Status Transitions
 

--- a/aidd_docs/memory/VCS.md
+++ b/aidd_docs/memory/VCS.md
@@ -35,7 +35,7 @@
 
 ### Scopes
 
-`users`, `games`, `characters`, `quotes`, `activitypub`, `api`
+`users`, `games`, `characters`, `activitypub`, `api`
 
 ### Rules
 

--- a/aidd_docs/memory/architecture.md
+++ b/aidd_docs/memory/architecture.md
@@ -194,7 +194,7 @@ C4Context
 
 ## Report Model Enhancements
 
-- `content_warning` field on `Report` (US-30)
+- `content_warning` field on `Report`
 - `visibility` field: PUBLIC / UNLISTED / FOLLOWERS (US-29)
 - `session_date` field on `Report`
 

--- a/aidd_docs/memory/external/alwaysdata-deployment.md
+++ b/aidd_docs/memory/external/alwaysdata-deployment.md
@@ -123,12 +123,6 @@ Fréquence : 0 3 * * *
 Commande  : /home/<user>/www/soudainement/venv/bin/python /home/<user>/www/soudainement/manage.py clearsessions
 ```
 
-**Nettoyage citations éphémères** (horaire) :
-```
-Fréquence : 0 * * * *
-Commande  : /home/<user>/www/soudainement/venv/bin/python /home/<user>/www/soudainement/manage.py shell -c "from suddenly.activitypub.tasks import cleanup_expired_quotes; cleanup_expired_quotes()"
-```
-
 ---
 
 ## Mise à jour

--- a/aidd_docs/memory/external/seeds.md
+++ b/aidd_docs/memory/external/seeds.md
@@ -93,7 +93,6 @@ Avec les valeurs par défaut :
 | Comptes-rendus | 400 | 200 `fr` / 200 `en`, brouillons et publiés, visibilités `public`/`unlisted`/`followers`, une partie `released` |
 | Rapports | ~2800 | Fils narratifs enchaînés par `RapportLink`, tous types confondus |
 | Images | ~430 | Avatars, couvertures, images de rapports |
-| Citations | ~110 | Publiques et privées |
 | Abonnements | 240 | Vers des personnages et des parties |
 | Liens | ~38 | Claims, adoptions et forks : certains en attente, d'autres acceptés, d'autres avec séquence partagée publiée |
 
@@ -101,7 +100,7 @@ Avec les valeurs par défaut :
 
 La langue est portée par **la campagne** : une partie est française ou anglaise, et ses comptes-rendus héritent de sa langue via `Report.language` (BCP-47). Le résultat est exactement équilibré, ce qui rend les filtres de langue et le `contentMap` ActivityPub testables sur des données réelles.
 
-Les textes ne sont pas générés au hasard : narration, actions, dialogues, citations et textes alternatifs des images existent dans les deux langues.
+Les textes ne sont pas générés au hasard : narration, actions, dialogues et textes alternatifs des images existent dans les deux langues.
 
 ### Les images
 

--- a/aidd_docs/memory/internal/API_DOCS.md
+++ b/aidd_docs/memory/internal/API_DOCS.md
@@ -94,9 +94,9 @@
 | Follow | User | User/Character/Game | Follow |
 | Accept | User | Follow/Offer | Accept |
 | Reject | User | Follow/Offer | Reject |
-| Create | User | Report/Quote/Character | Publish |
-| Update | User | Report/Quote/Character | Edit |
-| Delete | User | Report/Quote | Delete |
+| Create | User | Report/Character | Publish |
+| Update | User | Report/Character | Edit |
+| Delete | User | Report | Delete |
 | Announce | User | Report | Share |
 | Offer | User | Claim/Adopt/Fork | Propose link |
 
@@ -110,7 +110,6 @@
 | `suddenly:originGame` | Character's origin game |
 | `suddenly:creator` | Original creator |
 | `suddenly:appearances` | Appearances in reports |
-| `suddenly:quotes` | Character quotes |
 | `suddenly:links` | Claim/Adopt/Fork links |
 | `suddenly:gameSystem` | Game system |
 | `suddenly:targetCharacter` | Target NPC (for Offer) |
@@ -134,6 +133,5 @@ keyId: https://instance/actor#main-key
 | Suddenly Type | Displayed as |
 |---------------|--------------|
 | Report (Article) | Article |
-| Quote (Note) | Note |
 | Character (Person) | Person |
 | Offer(Claim/Adopt/Fork) | Not sent to non-Suddenly instances |

--- a/aidd_docs/memory/internal/DATABASE.md
+++ b/aidd_docs/memory/internal/DATABASE.md
@@ -24,7 +24,7 @@ flowchart LR
 
 - `User` owns `Game`s, creates/owns `Character`s, authors `Report`s
 - `Game` has many `Report`s and `Character`s (via `origin_game`)
-- `Character` has `Quote`s, `CharacterAppearance`s, receives `LinkRequest`s
+- `Character` has `CharacterAppearance`s, receives `LinkRequest`s
 - `LinkRequest` → accepted → creates `CharacterLink` + `SharedSequence`
 - `Follow` is polymorphic (targets `User`, `Character`, or `Game`)
 
@@ -38,7 +38,6 @@ erDiagram
     User ||--o{ Character : "creates/owns"
     Game ||--o{ Report : has
     Game ||--o{ Character : "origin_game"
-    Character ||--o{ Quote : has
     Character ||--o{ CharacterAppearance : appears_in
     Report ||--o{ CharacterAppearance : features
     Report ||--o{ ReportCast : planned_via
@@ -80,7 +79,6 @@ Fork           (derivation: creates a new PC with parent=NPC; NPC stays NPC — 
 | Game | games | Group | `title`, `owner`, `is_public`, `ap_id`, `local` |
 | Report | games | Article | `content` (Markdown), `game`, `author`, `status` (DRAFT/PUBLISHED), `language`, `content_warning` (CharField 500 optional), `visibility` (PUBLIC/UNLISTED/FOLLOWERS), `session_date` (DateField optional) |
 | Character | characters | Person | `name`, `status` (NPC/PC/CLAIMED/ADOPTED), `owner`, `creator`, `origin_game`, `parent` (fork lineage) |
-| Quote | characters | Note | `content`, `character`, `visibility` (EPHEMERAL/PRIVATE/PUBLIC), `language` |
 | CharacterAppearance | characters | — | `character`, `report`, `role` (MAIN/SUPPORTING/MENTIONED) |
 | ReportCast | games | — | `report`, `character` (nullable), `new_character_name`, `role` |
 | LinkRequest | characters | Offer | `link_type` (CLAIM/ADOPT/FORK), `requester`, `target_character`, `status` (PENDING/ACCEPTED/REJECTED/CANCELLED) |
@@ -94,7 +92,7 @@ Fork           (derivation: creates a new PC with parent=NPC; NPC stays NPC — 
 | UserBlock | core | — | `blocker` + `blocked` (User FKs), unique_together |
 | UserMute | core | — | `muter` + `muted` (User FKs), unique_together |
 | DonationPrompt | core | — | `user` (FK), `posts_at_prompt`, `donated`, `donated_at`, `amount_suggested` |
-| UserUsageStats | core | — | `user` (OneToOne), `total_posts`, `total_quotes`, `total_link_requests`, `posts_since_last_prompt`, `last_donation_date` |
+| UserUsageStats | core | — | `user` (OneToOne), `total_posts`, `total_link_requests`, `posts_since_last_prompt`, `last_donation_date` |
 | GameSystem | games | — | `name` (CharField) — game system taxonomy |
 | Rapport | games | — | `report` (FK to Report), `kind` (RapportKind: DESCRIPTION/ACTION/DISCUSSION/NARRATION), `content`, `actor` (Character FK nullable — required for DISCUSSION) |
 | RapportLink | games | — | `rapport` (FK), `parent_rapport` (FK nullable), `parent_iri` (URLField nullable) — exactly one of local/remote must be set |
@@ -105,7 +103,6 @@ Fork           (derivation: creates a new PC with parent=NPC; NPC stays NPC — 
 - `Character(status)` — list available NPCs
 - `Character(local, status)` — local available NPCs
 - `Report(game, status)` — published reports for a game
-- `Quote(character, visibility)` — public quotes
 - `LinkRequest(status, target_character)` — pending requests
 - `Follow(follower, target_type, target_id)` — unique
 - `Notification(recipient, read)` — unread count

--- a/aidd_docs/memory/internal/DESIGN.md
+++ b/aidd_docs/memory/internal/DESIGN.md
@@ -35,7 +35,7 @@ scope: frontend
 ## Colour carries domain meaning — not decoration
 
 - `color.domain.*` encodes narrative state; never repurpose for styling
-- `pc` = indigo `#6366f1` · `npc` = amber `#b45309` · `available` = neon `#00e676` · `remote`/`forked`/`oracle` = violet `#7c3aed` · `claimed` = blue · `adopted` = green · `quoted` = crimson
+- `pc` = indigo `#6366f1` · `npc` = amber `#b45309` · `available` = neon `#00e676` · `remote`/`forked`/`oracle` = violet `#7c3aed` · `claimed` = blue · `adopted` = green
 - **`brand.signal` (#00e676) never carries a glyph** — 1.6:1 on light ground. Text uses `domain.available-text` (`#0a8f4d`). Rule: `usage.rules[signal-never-text]`
 - A status is never colour-only: it pairs a `color.domain.*` token with a label or icon; avatar rings add a distinct `border.style`
 
@@ -104,6 +104,6 @@ scope: frontend
 
 ## Components (`templates/components/`)
 
-- Server-rendered Django partials: `character_card`, `game_card`, `report_card`, `quote_card`, `feed_item`, `link_request_card`, `notification_item`, `npc_highlight`, `empty_state`, `modal`, `follow_button`, `presence_indicator`, `password_strength`, `status_banner`, `tag_filter`, `report_editor`, `docs_sidebar`, `_fonts`
+- Server-rendered Django partials: `character_card`, `game_card`, `report_card`, `feed_item`, `link_request_card`, `notification_item`, `npc_highlight`, `empty_state`, `modal`, `follow_button`, `presence_indicator`, `password_strength`, `status_banner`, `tag_filter`, `report_editor`, `docs_sidebar`, `_fonts`
 - Form partials: `form_fields`, `form_image_upload`, `form_switch`
 - The 17 BEM components in `design/components.json` (`rap`, `badge--npc`, `card__body`…) come from mockup v3 and are **not integrated yet** — declared ahead of use

--- a/aidd_docs/tasks/2026_07/2026_07_22-145-retrait-quotes-docs.md
+++ b/aidd_docs/tasks/2026_07/2026_07_22-145-retrait-quotes-docs.md
@@ -1,0 +1,59 @@
+---
+objective: >
+  Épique #139 — PR 2 (#145) : purge des références Quotes dans la documentation normative
+  (mémoire auto-chargée) et les user stories. Complète le hard delete du code (PR 1, #170 mergée).
+success_condition: >
+  grep -rin "total_quotes|EPHEMERAL_QUOTE|cleanup_expired_quotes|quote_card|US-30|US-08" aidd_docs/memory/ .claude/rules/08-domain/08-activitypub.md aidd_docs/tasks/suddenly-stories.md → vide
+plan_kind: simple
+confidence: 9
+iteration: 1
+created_at: 2026-07-22
+---
+
+# Épique #139 — retrait des Quotes (PR 2 : docs / mémoire, #145)
+
+## Objectif
+
+Après le hard delete du code (PR 1, #170), purger les mentions Quote de la **doc normative
+auto-chargée** et des user stories, pour qu'aucun document décrivant une capacité disparue ne
+subsiste dans le contexte chargé à l'implémentation.
+
+## Fichiers purgés
+
+| Fichier | Retrait |
+|---------|---------|
+| `memory/PROJECT_BRIEF.md` | ligne glossaire Citation, pilier « publier des citations », ligne AP `Quote\|Note` |
+| `memory/internal/DATABASE.md` | table `Quote`, arêtes ER, index, `total_quotes` de `UserUsageStats` |
+| `memory/CODEBASE_MAP.md` | `Quote` du nœud characters |
+| `memory/CODING_ASSERTIONS.md` | assertions éphémères + `EPHEMERAL_QUOTE_TTL_HOURS` (+ section vidée) |
+| `memory/VCS.md` | scope de commit `quotes` |
+| `memory/internal/DESIGN.md` | `quote_card` + état `quoted` |
+| `memory/internal/API_DOCS.md` | verbes AP Quote, `suddenly:quotes`, ligne compat Mastodon |
+| `memory/DEPLOYMENT.md` | ligne crontab `cleanup_expired_quotes` |
+| `memory/external/alwaysdata-deployment.md` | bloc tâche planifiée « citations éphémères » |
+| `memory/architecture.md` | référence `(US-30)` obsolète sur `content_warning` (champ conservé) |
+| `memory/external/seeds.md` | ligne seed « Citations ~110 » + mention « citations » |
+| `.claude/rules/08-domain/08-activitypub.md` | mapping `Quote=Note` |
+| `tasks/suddenly-stories.md` | **US-08 « Citations »** (Domaine 5) + **US-30**, lignes gherkin (fiche perso, Note Mastodon), « CR ou citation » → « CR » dans US-25, lignes des tables de priorité |
+
+## Décisions
+
+- **US-08** (la vraie user story Quote, en français « Citations ») retirée en plus d'US-30 — le
+  périmètre initial ne nommait qu'US-30, mais US-08 décrivait la fonctionnalité supprimée.
+- **Hors périmètre (archives, laissés)** : `aidd_docs/wireframes/**` (mockups historiques, dont
+  `08-quotes.md`), `aidd_docs/tasks/MASTER_PLAN.md` et les plans/audits datés (records historiques
+  du build d'origine, où Quote existait), `memory/external/bookwyrm-architecture.md` (référence
+  externe). Cohérent avec la règle normative-vs-archive : on ne réécrit pas l'historique.
+
+## Vérification
+- Greps #145 (`total_quotes`, `EPHEMERAL_QUOTE`, `cleanup_expired_quotes`, `quote_card`, `US-30`,
+  `US-08`, `Domaine 5`) sur mémoire + règle AP + stories = **vide**.
+- Refs `quote`/`citation` restantes uniquement dans les archives historiques (MASTER_PLAN,
+  wireframes, plans datés) et faux positifs (`blockquote`, « single quotes »).
+
+## Points de vigilance
+- **Pas de renumérotation** des US/domaines restants (gap Domaine 4→6 assumé, archive lisible).
+- **Aucun code/test/.po touché** — PR strictement documentaire.
+
+## Évaluation de confiance : 9/10
+Purge documentaire ciblée sur la couche normative, archives préservées, vérif grep verte.

--- a/aidd_docs/tasks/suddenly-stories.md
+++ b/aidd_docs/tasks/suddenly-stories.md
@@ -110,7 +110,6 @@ Scenario: Mention de personnage
 Scenario: Consultation de fiche
   Given je clique sur un personnage
   Then je vois son nom, description, avatar, statut et ses apparitions
-  And je vois ses citations mémorables
   And si c'est un PNJ disponible, les boutons Adopter/Réclamer/Dériver sont visibles
 ```
 
@@ -135,24 +134,6 @@ Scenario: Filtrage par tag
   Given j'utilise la barre de filtres
   When je sélectionne un tag
   Then seuls les personnages portant ce tag s'affichent
-```
-
----
-
-## Domaine 5 — Citations
-
-### US-08: "Ajouter une citation"
-
-**As a** joueur solo
-**I want** enregistrer une réplique mémorable d'un personnage
-**So that** les moments forts de mes parties soient préservés
-
-```gherkin
-Scenario: Ajout de citation
-  Given je suis sur la fiche d'un personnage ou dans un CR
-  When j'ajoute une citation avec son contexte
-  Then la citation apparaît sur la fiche du personnage et est fédérée si publique
-  And je peux choisir Éphémère / Privée / Publique
 ```
 
 ---
@@ -532,11 +513,6 @@ Scenario: CR visible comme Article
   Then il apparaît comme un Article dans mon fil Mastodon
   And je peux lire le contenu et voir le lien vers la source
 
-Scenario: Citation visible comme Note
-  Given je suis un personnage Suddenly depuis Mastodon
-  When une citation publique est ajoutée
-  Then elle apparaît comme une Note dans mon fil
-
 Scenario: Activités Suddenly-only
   Given une Offer (Claim/Adopt/Fork) est émise
   Then elle n'est PAS envoyée aux instances non-Suddenly
@@ -555,7 +531,7 @@ Scenario: Activités Suddenly-only
 
 ```gherkin
 Scenario: Suppression de contenu
-  Given un CR ou une citation est signalé
+  Given un CR est signalé
   When je le supprime en tant qu'admin
   Then le contenu est masqué (soft delete)
   And l'auteur est notifié avec la raison
@@ -667,23 +643,6 @@ Scenario: Visibilite abonnes
   Then seuls mes followers le voient
 ```
 
-### US-30: "Ajouter un avertissement de contenu"
-
-**As a** joueur qui publie du contenu sensible
-**I want** ajouter un avertissement de contenu (CW)
-**So that** les lecteurs choisissent de voir ou non le contenu
-
-```gherkin
-Scenario: CR avec CW
-  Given je publie un CR avec un avertissement "Violence"
-  Then le CR est replie dans le fil derriere "Afficher le contenu"
-  And le CW est transmis dans l'activite AP
-
-Scenario: Citation avec CW
-  Given j'ajoute une citation avec un avertissement "Contenu mature"
-  Then la citation est repliee sur la fiche personnage
-```
-
 ### US-31: "Voir les details de mon instance"
 
 **As a** visiteur ou joueur
@@ -713,7 +672,6 @@ Scenario: Citation avec CW
 | 2 | US-13 | GM — Distribution | Prérequis pour la rédaction de CRs |
 | 3 | US-04, US-05 | Comptes-rendus | Valeur principale |
 | 4 | US-06, US-07 | Personnages | Découle des CRs |
-| 5 | US-08 | Citations | Gain immédiat, haute valeur perçue |
 | 5 | US-20, US-21 | Notifications | Nécessaire dès que les interactions existent |
 | 6 | US-09, US-10, US-11 | Liens (base) | Le gameplay — arrive quand la base existe |
 | 6 | US-14 | GM — Arbitrage | Prérequis pour le workflow de liens |
@@ -723,7 +681,7 @@ Scenario: Citation avec CW
 | 7 | US-23 | Lien cross-instance | Fédération gameplay |
 | 7 | US-24 | Compatibilité Mastodon | Visibilité externe |
 | 7 | US-25, US-26, US-27 | Administration | Gouvernance d'instance |
-| 3 | US-29, US-30 | Fediverse natif | Visibilite + CW : requis avant publication de CRs |
+| 3 | US-29 | Fediverse natif | Visibilite : requis avant publication de CRs |
 | 5 | US-28 | Fediverse natif | Recommandation : propagation de contenu |
 | 6 | US-31 | Fediverse natif | Page A propos : identite d'instance |
 | 7 | US-32, US-33 | Fediverse natif | Import/export, block/mute : portabilite |


### PR DESCRIPTION
Deuxième et dernière PR de l'épique **#139 — Retrait des Quotes**. Purge documentaire (#145), après le hard delete du code (#170, mergé). **Doc uniquement — aucun code, test ou `.po` touché.**

## Ce qui est purgé (doc normative + user stories)

- **Mémoire auto-chargée** : `PROJECT_BRIEF` (pilier « citations », glossaire, ligne AP), `internal/DATABASE` (table `Quote` + `total_quotes`), `CODEBASE_MAP`, `CODING_ASSERTIONS` (`EPHEMERAL_QUOTE_TTL_HOURS`), `VCS` (scope `quotes`), `internal/DESIGN` (`quote_card`/état `quoted`), `internal/API_DOCS` (verbes AP + `suddenly:quotes` + ligne Mastodon), `DEPLOYMENT` + `external/alwaysdata-deployment` (cron `cleanup_expired_quotes`), `architecture` (réf `(US-30)` obsolète), `external/seeds` (ligne seed « Citations »).
- **Règle** : `.claude/rules/08-domain/08-activitypub.md` (mapping `Quote=Note`).
- **User stories** (`suddenly-stories.md`) : **US-08 « Citations »** (tout le Domaine 5) + **US-30** retirées ; lignes gherkin obsolètes (fiche perso, Note Mastodon) et lignes de tables de priorité nettoyées ; « CR ou citation » → « CR ».

## Hors périmètre (archives préservées)

Cohérent avec la règle *normative-vs-archive* — on ne réécrit pas l'historique : `aidd_docs/wireframes/**` (mockups, dont `08-quotes.md`), `aidd_docs/tasks/MASTER_PLAN.md` + plans/audits datés (record du build d'origine où Quote existait), `memory/external/bookwyrm-architecture.md` (référence externe).

## Vérification

Greps #145 (`total_quotes`, `EPHEMERAL_QUOTE`, `cleanup_expired_quotes`, `quote_card`, `US-30`, `US-08`, `Domaine 5`) sur mémoire + règle AP + stories = **vide**. Refs `quote`/`citation` restantes uniquement dans les archives historiques et faux positifs (`blockquote`, « single quotes »).

Closes #145
Refs #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBRFVUtmBW3YSP8Yd2uNpB)_