### PR TITLE
test(offers,messaging): couverture OfferService & MessageService (#132, #135)

### DIFF
--- a/tests/messaging/test_message_service.py
+++ b/tests/messaging/test_message_service.py
@@ -1,0 +1,107 @@
+"""Tests for MessageService — federated direct messages (Epic E, #135).
+
+Covers the DEC-E invariants: canonical pair ordering + idempotent conversation
+(E1), the mutual-follow send gate (E2), idempotent remote receive by ap_id (E4),
+and the unread read-cursor logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+
+from suddenly.characters.models import Follow
+from suddenly.messaging.models import Conversation, DirectMessage
+from suddenly.messaging.services import MessageService, NotMutualFollowersError
+from suddenly.users.models import User
+from tests.factories import UserFactory
+
+
+def _follow(follower: User, target: User) -> None:
+    """Create an accepted User→User follow."""
+    Follow.objects.create(
+        follower=follower,
+        content_type=ContentType.objects.get_for_model(User),
+        object_id=target.pk,
+        accepted=True,
+    )
+
+
+def _make_mutual(a: User, b: User) -> None:
+    _follow(a, b)
+    _follow(b, a)
+
+
+@pytest.fixture
+def alice(db: Any) -> User:
+    return UserFactory(username="alice", email="alice@example.com")  # type: ignore[return-value,no-untyped-call]
+
+
+@pytest.fixture
+def bob(db: Any) -> User:
+    return UserFactory(username="bob", email="bob@example.com")  # type: ignore[return-value,no-untyped-call]
+
+
+@pytest.mark.django_db
+class TestConversation:
+    def test_pair_is_canonical_and_idempotent(self, alice: User, bob: User) -> None:
+        conv1, created1 = MessageService.get_or_create_conversation(alice, bob)
+        conv2, created2 = MessageService.get_or_create_conversation(bob, alice)
+        assert created1 is True
+        assert created2 is False
+        assert conv1.pk == conv2.pk
+        assert Conversation.objects.count() == 1
+
+    def test_other_participant(self, alice: User, bob: User) -> None:
+        conv, _ = MessageService.get_or_create_conversation(alice, bob)
+        assert MessageService.other_participant(conv, alice) == bob
+        assert MessageService.other_participant(conv, bob) == alice
+
+
+@pytest.mark.django_db
+class TestSendGate:
+    def test_send_requires_mutual_follow(self, alice: User, bob: User) -> None:
+        with pytest.raises(NotMutualFollowersError):
+            MessageService.send(alice, bob, "salut")
+        # one-directional is still not mutual
+        _follow(alice, bob)
+        with pytest.raises(NotMutualFollowersError):
+            MessageService.send(alice, bob, "salut")
+        assert DirectMessage.objects.count() == 0
+
+    def test_send_succeeds_when_mutual(self, alice: User, bob: User) -> None:
+        _make_mutual(alice, bob)
+        msg = MessageService.send(alice, bob, "salut")
+        assert msg.body == "salut"
+        assert msg.sender == alice
+        assert msg.remote is False
+        msg.conversation.refresh_from_db()
+        assert msg.conversation.last_message_at is not None
+
+
+@pytest.mark.django_db
+class TestReceiveRemote:
+    def test_receive_is_idempotent_by_ap_id(self, alice: User, bob: User) -> None:
+        conv, _ = MessageService.get_or_create_conversation(alice, bob)
+        ap_id = "https://remote.example/messages/1"
+        m1 = MessageService.receive_remote(conv, bob, "coucou", ap_id=ap_id)
+        m2 = MessageService.receive_remote(conv, bob, "coucou", ap_id=ap_id)
+        assert m1.pk == m2.pk
+        assert DirectMessage.objects.filter(ap_id=ap_id).count() == 1
+
+
+@pytest.mark.django_db
+class TestUnread:
+    def test_unread_then_mark_read(self, alice: User, bob: User) -> None:
+        _make_mutual(alice, bob)
+        MessageService.send(bob, alice, "un")
+        MessageService.send(bob, alice, "deux")
+        conv, _ = MessageService.get_or_create_conversation(alice, bob)
+        # Alice has two unread from bob; bob has none from alice.
+        assert MessageService.unread_for(conv, alice) == 2
+        assert MessageService.unread_for(conv, bob) == 0
+        MessageService.mark_read(conv, alice)
+        assert MessageService.unread_for(conv, alice) == 0
+        assert MessageService.unread_count(alice) == 0

--- a/tests/offers/test_offer_service.py
+++ b/tests/offers/test_offer_service.py
@@ -1,0 +1,111 @@
+"""Tests for OfferService — social Offers replacing Muses (Epic B, #132).
+
+Covers the service invariants on the SUMMARY seam (carrier IS a Report):
+idempotent open, one response per responder, accept materializes a Rapport +
+declines siblings + resolves the offer (idempotent), decline, and expiry.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from suddenly.games.models import Report
+from suddenly.offers.models import (
+    OfferKind,
+    OfferResponseStatus,
+    OfferStatus,
+    SocialOffer,
+)
+from suddenly.offers.services import OfferService
+from suddenly.users.models import User
+from tests.factories import UserFactory
+
+
+@pytest.fixture
+def responder(db: Any) -> User:
+    return UserFactory(  # type: ignore[return-value,no-untyped-call]
+        username="responder", email="responder@example.com"
+    )
+
+
+@pytest.fixture
+def responder2(db: Any) -> User:
+    return UserFactory(  # type: ignore[return-value,no-untyped-call]
+        username="responder2", email="responder2@example.com"
+    )
+
+
+@pytest.mark.django_db
+class TestOpenOffer:
+    def test_open_is_idempotent(self, user: User, report: Report) -> None:
+        first = OfferService.open_offer(kind=OfferKind.SUMMARY, carrier=report, emitter=user)
+        second = OfferService.open_offer(kind=OfferKind.SUMMARY, carrier=report, emitter=user)
+        assert first.pk == second.pk
+        assert SocialOffer.objects.count() == 1
+        assert first.status == OfferStatus.OPEN
+
+
+@pytest.mark.django_db
+class TestRespond:
+    def test_one_response_per_responder(self, user: User, report: Report, responder: User) -> None:
+        offer = OfferService.open_offer(kind=OfferKind.SUMMARY, carrier=report, emitter=user)
+        r1 = OfferService.respond(offer=offer, responder=responder, content="première")
+        r2 = OfferService.respond(offer=offer, responder=responder, content="corrigée")
+        assert r1.pk == r2.pk
+        r2.refresh_from_db()
+        assert r2.content == "corrigée"
+        assert offer.responses.count() == 1
+
+
+@pytest.mark.django_db
+class TestAcceptResponse:
+    def test_accept_materializes_post_declines_siblings_resolves(
+        self, user: User, report: Report, responder: User, responder2: User
+    ) -> None:
+        offer = OfferService.open_offer(kind=OfferKind.SUMMARY, carrier=report, emitter=user)
+        chosen = OfferService.respond(offer=offer, responder=responder, content="le bon texte")
+        sibling = OfferService.respond(offer=offer, responder=responder2, content="autre")
+
+        accepted = OfferService.accept_response(chosen)
+
+        assert accepted.status == OfferResponseStatus.ACCEPTED
+        assert accepted.created_post is not None
+        assert accepted.created_post.content == "le bon texte"
+
+        sibling.refresh_from_db()
+        assert sibling.status == OfferResponseStatus.DECLINED
+
+        offer.refresh_from_db()
+        assert offer.status == OfferStatus.RESOLVED
+
+    def test_accept_is_idempotent(self, user: User, report: Report, responder: User) -> None:
+        offer = OfferService.open_offer(kind=OfferKind.SUMMARY, carrier=report, emitter=user)
+        chosen = OfferService.respond(offer=offer, responder=responder, content="texte")
+        first = OfferService.accept_response(chosen)
+        post_pk = first.created_post_id
+        second = OfferService.accept_response(chosen)
+        assert second.created_post_id == post_pk
+        assert report.rapports.count() == 1
+
+
+@pytest.mark.django_db
+class TestDeclineAndExpire:
+    def test_decline_pending_response(self, user: User, report: Report, responder: User) -> None:
+        offer = OfferService.open_offer(kind=OfferKind.SUMMARY, carrier=report, emitter=user)
+        resp = OfferService.respond(offer=offer, responder=responder, content="texte")
+        OfferService.decline_response(resp)
+        resp.refresh_from_db()
+        assert resp.status == OfferResponseStatus.DECLINED
+
+    def test_expire_for_carrier_closes_open_offers(
+        self, user: User, report: Report, responder: User
+    ) -> None:
+        offer = OfferService.open_offer(kind=OfferKind.SUMMARY, carrier=report, emitter=user)
+        resp = OfferService.respond(offer=offer, responder=responder, content="texte")
+        OfferService.expire_for_carrier(report)
+        offer.refresh_from_db()
+        resp.refresh_from_db()
+        assert offer.status == OfferStatus.EXPIRED
+        assert resp.status == OfferResponseStatus.DECLINED


### PR DESCRIPTION
Les épiques **#132 (Offer sociale)** et **#135 (MP fédérés)** ont été livrées en code (modèles, services, vues, AP entrant/sortant, UI) mais **sans aucun test** (`tests/offers/` inexistant, `tests/messaging/` vide). Cette PR comble ce manque avec une couverture ciblée au niveau service.

## `tests/offers/test_offer_service.py` (#132)

Sur la couture SUMMARY (le carrier EST un `Report`) :
- `open_offer` idempotent (pas de doublon pour `(carrier, kind, open)`)
- `respond` : une réponse par `(offer, responder)`, mise à jour du contenu si encore `pending`
- `accept_response` : matérialise un `Rapport`, décline les réponses sœurs `pending`, résout l'offre — et re-accepter est idempotent (pas de second Rapport)
- `decline_response`
- `expire_for_carrier` : expire les offres ouvertes + décline les réponses en attente

## `tests/messaging/test_message_service.py` (#135)

Invariants DEC-E :
- **E1** — `get_or_create_conversation` : paire canonique (même row quel que soit l'ordre), idempotente
- **E2** — `send` lève `NotMutualFollowersError` sans follow mutuel (un sens seul ne suffit pas), réussit et met à jour `last_message_at` quand mutuel
- **E4** — `receive_remote` idempotent par `ap_id`
- lecture : `unread_for` / `mark_read` / `unread_count`

## Vérification

`ruff format --check .` + `ruff check .` clean · `mypy` clean · `pytest tests/offers/ tests/messaging/` = **12 passed**. Aucun code de production modifié (tests seuls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBRFVUtmBW3YSP8Yd2uNpB)_